### PR TITLE
Modify utils/bin.cpp

### DIFF
--- a/utils/bin.cpp
+++ b/utils/bin.cpp
@@ -4,8 +4,8 @@
 
 #include <stdio.h>
 
-void printBits(char palabra, bool new_line=true){
-  for (char i = 7; i >= 0; i--){
+void printBits(char palabra, bool new_line=true, int length=8){
+  for (char i = length-1; i >= 0; i--){
     printf("%d", (palabra >> i) & 1);
   }
   if (new_line) {
@@ -13,8 +13,8 @@ void printBits(char palabra, bool new_line=true){
   }
 }
 
-void printBits(short palabra, bool new_line=true) {
-  for (char i = 15; i >= 0; i--){
+void printBits(short palabra, bool new_line=true, int length=16) {
+  for (char i = length-1; i >= 0; i--){
     printf("%d", (palabra >> i) & 1);
   }
   if (new_line) {
@@ -22,8 +22,8 @@ void printBits(short palabra, bool new_line=true) {
   }
 }
 
-void printBits(int palabra, bool new_line=true) {
-  for (char i = 31; i >= 0; i--){
+void printBits(int palabra, bool new_line=true, int length=32) {
+  for (char i = length-1; i >= 0; i--){
     printf("%d", (palabra >> i) & 1);
   }
   if (new_line) {
@@ -31,13 +31,44 @@ void printBits(int palabra, bool new_line=true) {
   }
 }
 
-// Imprimir Signo | Exponente | Mantisa de un número en OF de 32 bits.
+
+// Overloads con el orden inverso de los parámetros.
+
+void printBits(char palabra, int length=8, bool new_line=true){
+  for (char i = length-1; i >= 0; i--){
+    printf("%d", (palabra >> i) & 1);
+  }
+  if (new_line) {
+    printf("\n");
+  }
+}
+
+void printBits(short palabra, int length=16, bool new_line=true) {
+  for (char i = length-1; i >= 0; i--){
+    printf("%d", (palabra >> i) & 1);
+  }
+  if (new_line) {
+    printf("\n");
+  }
+}
+
+void printBits(int palabra, int length=32, bool new_line=true) {
+  for (char i = length-1; i >= 0; i--){
+    printf("%d", (palabra >> i) & 1);
+  }
+  if (new_line) {
+    printf("\n");
+  }
+}
+
+
+// Imprimir Signo | Exponente | Mantisa de un número en PF de 32 bits.
 void printFP(int palabra, bool new_line=true) {
-    printBits(palabra >> 31, false);
+    printBits(palabra >> 31, 1, false);
     printf(" | ");
-    printBits(palabra >> 23 & 0xFF, false);
+    printBits(palabra >> 23 & 0xFF, 8, false);
     printf(" | ");
-    printBits(palabra & 0x7FFFFF, false);
+    printBits(palabra & 0x7FFFFF, 23, false);
     if (new_line){
         printf("\n");
     }

--- a/utils/bin.cpp
+++ b/utils/bin.cpp
@@ -4,6 +4,10 @@
 
 #include <stdio.h>
 
+//=======================================================//
+// Procedimientos para mostrar representaciones binarias //
+//=======================================================//
+
 void printBits(char palabra, bool new_line=true, int length=8){
   for (char i = length-1; i >= 0; i--){
     printf("%d", (palabra >> i) & 1);
@@ -31,6 +35,14 @@ void printBits(int palabra, bool new_line=true, int length=32) {
   }
 }
 
+void printBits(long palabra, bool new_line=true, int length=64) {
+  for (char i = length-1; i >= 0; i--){
+    printf("%d", (palabra >> i) & 1);
+  }
+  if (new_line) {
+    printf("\n");
+  }
+}
 
 // Overloads con el orden inverso de los parámetros.
 
@@ -61,14 +73,42 @@ void printBits(int palabra, int length=32, bool new_line=true) {
   }
 }
 
+void printBits(long palabra, int length=64, bool new_line=true) {
+  for (char i = length-1; i >= 0; i--){
+    printf("%d", (palabra >> i) & 1);
+  }
+  if (new_line) {
+    printf("\n");
+  }
+}
 
-// Imprimir Signo | Exponente | Mantisa de un número en PF de 32 bits.
+// Imprimir Signo | Exponente | Mantisa de un número en PF.
+void printFP(short palabra, bool new_line=true) {
+    printBits(palabra >> 15, 1, false);
+    printf(" | ");
+    printBits(palabra >> 10 & 0x1F, 5, false);
+    printf(" | ");
+    printBits(palabra & 0x3FF, 10, false);
+    if (new_line) printf("\n");
+}
+
 void printFP(int palabra, bool new_line=true) {
     printBits(palabra >> 31, 1, false);
     printf(" | ");
     printBits(palabra >> 23 & 0xFF, 8, false);
     printf(" | ");
     printBits(palabra & 0x7FFFFF, 23, false);
+    if (new_line){
+        printf("\n");
+    }
+}
+
+void printFP(long palabra, bool new_line=true) {
+    printBits(palabra >> 63, 1, false);
+    printf(" | ");
+    printBits(palabra >> 52 & 0x7FF, 11, false);
+    printf(" | ");
+    printBits(palabra & 0xFFFFFFFFFFFFF, 52, false);
     if (new_line){
         printf("\n");
     }


### PR DESCRIPTION
Se agrega la posibilidad de darle un parámetro a la función `printBits` para indicar el largo de la palabra. 
Se mejora también el procedimiento `printFP` para que solo imprima la cantidad de bits que precisa para componente.
![bob](https://github.com/Nanush7/utils-fing/assets/59491032/73f6d397-dd80-4a47-95ea-8046547f561a)
